### PR TITLE
Improve range picker plugins behavior and loading logic

### DIFF
--- a/js/actions/freerangepicker.js
+++ b/js/actions/freerangepicker.js
@@ -48,9 +48,10 @@ export function collapsePlugin() {
     };
 }
 
-export function markFreeRangeAsLoaded() {
+export function markFreeRangeAsLoaded(variabiliMeteo) {
     return {
-        type: PLUGIN_LOADED
+        type: PLUGIN_LOADED,
+        variabiliMeteo
     };
 }
 

--- a/js/components/datepickers/DailyManager.jsx
+++ b/js/components/datepickers/DailyManager.jsx
@@ -25,6 +25,7 @@ const DailyManager = ({
     format,
     defaultPeriod,
     isInteractionDisabled,
+    isLayerLoading,
     onChangePeriodToData,
     updateParams,
     alertMessage,
@@ -98,7 +99,7 @@ const DailyManager = ({
                 <Button  onClick={() => changeDateTime('days', -1)} disabled={isDecrementDayDisabled}>
                     <Glyphicon glyph="glyphicon glyphicon-chevron-left" />
                 </Button>
-                { isInteractionDisabled ? ( <LoadingSpinner />) : ( renderDateTimePicker() )}
+                { isLayerLoading ? ( <LoadingSpinner />) : ( renderDateTimePicker() )}
                 <Button onClick={() => changeDateTime('days', +1)} disabled={isIncrementDayDisabled}>
                     <Glyphicon glyph="glyphicon glyphicon-chevron-right" />
                 </Button>

--- a/js/epics/dateRangeConfig.js
+++ b/js/epics/dateRangeConfig.js
@@ -14,7 +14,7 @@ import { TOGGLE_PLUGIN, changePeriod, changePeriodToData } from '../actions/fixe
 import { changeFromData, changeToData  } from '../actions/freerangepicker';
 import DateAPI from '../utils/ManageDateUtils';
 import { getVisibleLayers, FIXED_RANGE, FREE_RANGE } from '@js/utils/VariabiliMeteoUtils';
-import { isVariabiliMeteoLayer } from '../utils/VariabiliMeteoUtils';
+import {  getVariabiliMeteo, isVariabiliMeteoLayer } from '../utils/VariabiliMeteoUtils';
 import moment from 'moment';
 import momentLocaliser from 'react-widgets/lib/localizers/moment';
 momentLocaliser(moment);
@@ -161,7 +161,7 @@ const updateRangePickerInfoEpic = (action$, store) =>
         .mergeMap(({layerId}) => {
             const currentState = store.getState();
             const layers = currentState.layers?.flat || [];
-            const variabiliMeteo = currentState.daterangelabel.variabiliMeteo;
+            const variabiliMeteo = getVariabiliMeteo(currentState);
             const activeLayer = layers.find(layer => layer.id === layerId);
             if (!activeLayer) {
                 return Observable.of(errorLayerNotFound(layerId));

--- a/js/epics/dateRangeConfig.js
+++ b/js/epics/dateRangeConfig.js
@@ -104,7 +104,7 @@ const updateParamsByDateRangeEpic = (action$, store) =>
             const timeUnit = action.payload.timeUnit;
             const defaultPeriod = action.payload.defaultPeriod;
             const isCheckPrefixes = appState.fixedrangepicker.checkPrefixes;
-            const variabiliMeteo = appState.fixedrangepicker.variabiliMeteo;
+            const variabiliMeteo = getVariabiliMeteo(appState);
             const actionsUpdateParams = updateLayersParams(layers, defaultPeriod, toData, timeUnit, isMapfilenameNotChange, isCheckPrefixes, variabiliMeteo);
             return Observable.of(...actionsUpdateParams);
         });

--- a/js/plugins/FixedRangePicker.jsx
+++ b/js/plugins/FixedRangePicker.jsx
@@ -331,6 +331,7 @@ class FixedRangePicker extends React.Component {
                 minDate={this.props.firstAvailableDate}
                 maxDate={this.props.lastAvailableDate}
                 isInteractionDisabled={this.props.isInteractionDisabled}
+                isLayerLoading={this.props.isLayerLoading}
                 onChangePeriodToData={this.props.onChangePeriodToData}
                 updateParams={this.updateParams}
                 alertMessage={this.props.alertMessage}

--- a/js/plugins/FixedRangePicker.jsx
+++ b/js/plugins/FixedRangePicker.jsx
@@ -244,6 +244,9 @@ class FixedRangePicker extends React.Component {
         if (this.props.alertMessage !== null) {
             this.props.onCloseAlert();
         }
+        if (this.props.isCollapsedPlugin) {
+            this.props.onCollapsePlugin();
+        }
     }
 
     render() {

--- a/js/plugins/FreeRangePicker.jsx
+++ b/js/plugins/FreeRangePicker.jsx
@@ -12,8 +12,9 @@ import { Button, ButtonGroup, Collapse, FormGroup, Glyphicon } from 'react-boots
 import Message from '@mapstore/components/I18N/Message';
 import { updateSettings, updateNode } from '@mapstore/actions/layers';
 import { layersSelector } from '@mapstore/selectors/layers';
-import { fromDataLayerSelector, toDataLayerSelector, isPluginLoadedSelector,
-    firstAvailableDateSelector, lastAvailableDateSelector } from '../selectors/freeRangePicker';
+import { fromDataLayerSelector, toDataLayerSelector, isPluginLoadedSelector, isCollapsedPluginSelector,
+    firstAvailableDateSelector, lastAvailableDateSelector, fromDataFormSelector,
+    toDataFormSelector } from '../selectors/freeRangePicker';
 import { compose } from 'redux';
 import { exportImageApiSelector, isLayerLoadingSelector } from '../selectors/exportImage';
 import DateAPI, { DATE_FORMAT, DEFAULT_DATA_FINE, DEFAULT_DATA_INIZIO} from '../utils/ManageDateUtils';
@@ -160,6 +161,9 @@ class FreeRangePicker extends React.Component {
         if (this.props.alertMessage) {
             this.props.onCloseAlert();
         }
+        if (this.props.isCollapsedPlugin) {
+            this.props.onCollapsePlugin();
+        }
     }
 
     render() {
@@ -289,9 +293,8 @@ class FreeRangePicker extends React.Component {
 }
 
 const mapStateToProps = createStructuredSelector({
-    isCollapsedPlugin: (state) => state?.freerangepicker?.isCollapsedPlugin,
-    fromData: (state) => state?.freerangepicker?.fromData,
-    toData: (state) => state?.freerangepicker?.toData,
+    isCollapsedPlugin: isCollapsedPluginSelector,
+    fromData: fromDataFormSelector,
     fromDataLayer: fromDataLayerSelector,
     settings: (state) => state?.layers?.settings || { expanded: false, options: { opacity: 1 } },
     layers: layersSelector,
@@ -304,6 +307,7 @@ const mapStateToProps = createStructuredSelector({
     isPluginLoaded: isPluginLoadedSelector,
     firstAvailableDate: firstAvailableDateSelector,
     lastAvailableDate: lastAvailableDateSelector,
+    toData: toDataFormSelector,
     toDataLayer: toDataLayerSelector
 });
 

--- a/js/plugins/FreeRangePicker.jsx
+++ b/js/plugins/FreeRangePicker.jsx
@@ -146,7 +146,7 @@ class FreeRangePicker extends React.Component {
 
     componentDidMount() {
         if (!this.props.isPluginLoaded) {
-            this.props.onMarkPluginAsLoaded();
+            this.props.onMarkPluginAsLoaded(this.props.variabiliMeteo);
             if ( this.props.isFetchAvailableDates && this.props.defaultUrlSelectDate && this.props.variabileSelectDate) {
                 const defaultPeriod = DateAPI.getDefaultPeriod(this.props.periodTypes);
                 this.props.onFetchAvailableDates(this.props.variabileSelectDate, this.props.defaultUrlSelectDate, this.props.timeUnit, defaultPeriod);

--- a/js/reducers/fixedrangepicker.js
+++ b/js/reducers/fixedrangepicker.js
@@ -80,7 +80,8 @@ function fixedrangepicker(state = defaultState, action) {
     case PLUGIN_NOT_LOADED:
         return {
             ...state,
-            isPluginLoaded: false
+            isPluginLoaded: false,
+            checkPrefixes: false
         };
     case FETCHED_AVAILABLE_DATES:
         const newDataFine = action.dataFine || DEFAULT_DATA_FINE;

--- a/js/reducers/freerangepicker.js
+++ b/js/reducers/freerangepicker.js
@@ -68,7 +68,8 @@ function freerangepicker(state = defaultState, action) {
     case PLUGIN_LOADED:
         return {
             ...state,
-            isPluginLoaded: true
+            isPluginLoaded: true,
+            variabiliMeteo: action.variabiliMeteo
         };
     case PLUGIN_NOT_LOADED:
         return {

--- a/js/selectors/freeRangePicker.js
+++ b/js/selectors/freeRangePicker.js
@@ -47,3 +47,8 @@ export const lastAvailableDateSelector = createSelector(
     [getFreeRangePickerState],
     (freerangepicker) => freerangepicker?.lastAvailableDate
 );
+
+export const isCollapsedPluginSelector = createSelector(
+    [getFreeRangePickerState],
+    (freerangepicker) => freerangepicker?.isCollapsedPlugin || false
+);

--- a/js/utils/VariabiliMeteoUtils.js
+++ b/js/utils/VariabiliMeteoUtils.js
@@ -72,6 +72,15 @@ function getIntersection(x1, y1, x2, y2, climY1, climY2) {
 
     return [intersectionX, yIntersect];
 }
+
+export function getVariabiliMeteo(currentState) {
+    if (currentState.fixedrangepicker?.isPluginLoaded ) {
+        return currentState.fixedrangepicker?.variabiliMeteo;
+    }
+    return currentState.freerangepicker?.variabiliMeteo;
+}
+
+
 /**
  * Colors the areas between the observed data and climatology using two different colors:
  * one color if the observed values are below climatology, and another color if they are above.


### PR DESCRIPTION
This PR introduces several improvements and fixes to the FixedRangePicker and FreeRangePicker plugins:
-Ensures that the plugin state is properly restored on unmount (specifically the checkPrefixes prop).
-Introduces the getVariabiliMeteo utility to consistently retrieve variabiliMeteo based on the active plugin.
-Sets variabiliMeteo on mount for FreeRangePlugin.
-Improves updateRangePickerInfoEpic.
-Replaces isInteractionDisabled with isLayerLoading in DailyManager to prevent unnecessary spinner appearance.
-Includes minor UI/UX improvements and logic consistency updates (e.g., restoring flags, managing loading spinners).