### PR TITLE
fix: ensures Chart's TabBar visibility

### DIFF
--- a/js/components/infochart/InfoChart.jsx
+++ b/js/components/infochart/InfoChart.jsx
@@ -16,7 +16,6 @@ import Dialog from '@mapstore/components/misc/Dialog';
 import BorderLayout from '@mapstore/components/layout/BorderLayout';
 import InfoChartForm from './InfoChartForm';
 import InfoChartRender from './InfoChartRender';
-import TabBar from '../buttons/TabBar';
 import DateAPI, { DATE_FORMAT, DEFAULT_DATA_INIZIO, DEFAULT_DATA_FINE } from '../../utils/ManageDateUtils';
 import { FIXED_RANGE, MARKER_ID, MULTI_VARIABLE_CHART, getStartPositionPanel, getDefaultPanelSize }  from '../../utils/VariabiliMeteoUtils';
 import { get, isEqual } from 'lodash';
@@ -310,35 +309,23 @@ class InfoChart extends React.Component {
     showChart = () => {
         if (!this.props.maskLoading) {
             const activeTab = this.getActiveTab();
-            let isTabBarVisible = false;
             let chartTypeSelected = {};
             if (activeTab.chartType === MULTI_VARIABLE_CHART) {
                 chartTypeSelected = this.getMultiVariableChartParams();
-            } else { // get chart type of single variable and check if chart choice tab bar is visible
+            } else {
                 chartTypeSelected = this.getSingleVariableChartParams(activeTab);
-                isTabBarVisible = activeTab.variables[0].chartList && activeTab.variables[0].chartList.length > 1;
             }
             return (
-                <div id="infochart-rendering">
-                    { isTabBarVisible && !this.props.isCollapsedFormGroup && // this.props.infoChartSize.widthResizable >= 550 &&
-                        !this.props.alertMessage &&
-                        <TabBar tabList={activeTab.variables[0].chartList}
-                            activeTab={activeTab.variables[0].chartList.find(chart =>
-                                chart.active)}
-                            onChangeTab={this.handleChangeChartType}
-                            classAttribute={"chart-type"} />
-                    }
-                    <InfoChartRender
-                        dataFetched = {this.props.data}
-                        handleRelayout= { this.handleRelayout }
-                        chartRelayout= { this.props.chartRelayout}
-                        infoChartSize={ this.props.infoChartSize}
-                        isCollapsedFormGroup={this.props.isCollapsedFormGroup}
-                        variableChartParams={ chartTypeSelected }
-                        unitPrecipitazione = { this.props.unitPrecipitazione }
-                        format={ this.props.timeUnit }
-                    />
-                </div>);
+                <InfoChartRender
+                    dataFetched = {this.props.data}
+                    handleRelayout= { this.handleRelayout }
+                    chartRelayout= { this.props.chartRelayout}
+                    infoChartSize={ this.props.infoChartSize}
+                    isCollapsedFormGroup={this.props.isCollapsedFormGroup}
+                    variableChartParams={ chartTypeSelected }
+                    unitPrecipitazione = { this.props.unitPrecipitazione }
+                    format={ this.props.timeUnit }
+                />);
         }
         return null;
     }
@@ -380,6 +367,7 @@ class InfoChart extends React.Component {
                     alertMessage={this.props.alertMessage}
                     toDataSelected={this.state.toDataSelected}
                     fromDataSelected={this.state.fromDataSelected}
+                    handleChangeChartType={this.handleChangeChartType}
                 />
             </div>
         );

--- a/js/components/infochart/InfoChart.jsx
+++ b/js/components/infochart/InfoChart.jsx
@@ -9,19 +9,16 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Resizable } from 'react-resizable';
 
-import { Collapse, Button, ButtonGroup, Glyphicon, Panel, Grid, FormGroup, Label} from 'react-bootstrap';
+import { Collapse, Button, Glyphicon} from 'react-bootstrap';
 import Message from '@mapstore/components/I18N/Message';
 
 import Dialog from '@mapstore/components/misc/Dialog';
 import BorderLayout from '@mapstore/components/layout/BorderLayout';
+import InfoChartForm from './InfoChartForm';
 import InfoChartRender from './InfoChartRender';
-import SelectVariableTab from '../buttons/SelectVariableTab';
 import TabBar from '../buttons/TabBar';
-import FixedRangeManager from '../../components/datepickers/FixedRangeManager';
-import FreeRangeManager from '../../components/datepickers/FreeRangeManager';
 import DateAPI, { DATE_FORMAT, DEFAULT_DATA_INIZIO, DEFAULT_DATA_FINE } from '../../utils/ManageDateUtils';
-import { FIXED_RANGE, FREE_RANGE, MARKER_ID, MULTI_VARIABLE_CHART, getStartPositionPanel,
-    getDefaultPanelSize }  from '../../utils/VariabiliMeteoUtils';
+import { FIXED_RANGE, MARKER_ID, MULTI_VARIABLE_CHART, getStartPositionPanel, getDefaultPanelSize }  from '../../utils/VariabiliMeteoUtils';
 import { get, isEqual } from 'lodash';
 import moment from 'moment';
 import momentLocaliser from 'react-widgets/lib/localizers/moment';
@@ -200,7 +197,6 @@ class InfoChart extends React.Component {
     initializeTabs = () => {
         const variableTabs = this.props.tabList.map((tab, index) => ({
             id: tab.id,
-            // TODO aggiungi tutte le variabile con un flag active true\false
             variables: [tab.groupList[0]],
             active: index === 0,
             chartType: tab.chartType,
@@ -247,10 +243,6 @@ class InfoChart extends React.Component {
         // Aggiorna le dimensioni del pannello
         this.props.onResizeInfoChart(size.width, size.height);
     };
-    switchRangeManager = () => {
-        const newRangeManager = this.props.activeRangeManager === FIXED_RANGE ? FREE_RANGE : FIXED_RANGE;
-        this.props.onSetRangeManager(newRangeManager);
-    }
     handleRelayout = (eventData) => {
         // Autoscale case: reset zoom data to default values
         if (eventData['xaxis.autorange'] || eventData['yaxis.autorange'] || eventData['yaxis2.autorange']) {
@@ -328,7 +320,7 @@ class InfoChart extends React.Component {
             }
             return (
                 <div id="infochart-rendering">
-                    { isTabBarVisible && !this.props.isCollapsedFormGroup && this.props.infoChartSize.widthResizable >= 550 &&
+                    { isTabBarVisible && !this.props.isCollapsedFormGroup && // this.props.infoChartSize.widthResizable >= 550 &&
                         !this.props.alertMessage &&
                         <TabBar tabList={activeTab.variables[0].chartList}
                             activeTab={activeTab.variables[0].chartList.find(chart =>
@@ -357,77 +349,39 @@ class InfoChart extends React.Component {
         </span>
         );
     }
+
     getPanelFormGroup = () => {
+        const tabSelected = this.getActiveTab();
         return (
-            <Panel className="infochart-panel">
-                <Grid fluid style={{padding: 0}}>
-                    <FormGroup>
-                        <Label className="labels-infochart"><Message msgId="infochart.selectMeteoVariable"/></Label>
-                        <SelectVariableTab
-                            idContainer="infochart-dropdown-container"
-                            tabList={this.props.tabList}
-                            onChangeSingleVariable={this.updateSingleVariable}
-                            onChangeMultiVariable={this.props.onChangeChartVariable}
-                            activeTab={this.getActiveTab()}
-                            onChangeTab={this.handleChangeTab}
-                            isInteractionDisabled={false}
-                        />
-                        {/* Toggle between FixedRangeManager and FreeRangeManager based on activeRangeManager*/}
-                        {this.props.activeRangeManager === FIXED_RANGE ? (
-                            <FixedRangeManager
-                                minDate={this.props.firstAvailableDate}
-                                maxDate={this.props.lastAvailableDate}
-                                toData={this.props.toData}
-                                periodType={this.props.periodType}
-                                periodTypes={this.props.periodTypes}
-                                onChangeToData={this.props.onChangeFixedRangeTodata}
-                                onChangePeriod={this.handleChangePeriod}
-                                isInteractionDisabled={false}
-                                styleLabels="labels-infochart"
-                                classAttribute="infochart-fixedrangemanager-action"
-                                widthPanel = {this.props.infoChartSize.widthResizable}
-                                format={this.props.timeUnit}
-                            />
-                        ) : (
-                            <FreeRangeManager
-                                minDate={this.props.firstAvailableDate}
-                                maxDate={this.props.lastAvailableDate}
-                                fromData={this.props.fromData}
-                                toData={this.props.toData}
-                                onChangeFromData={this.props.onChangeFromData}
-                                onChangeToData={this.props.onChangeToData}
-                                isInteractionDisabled={false}
-                                styleLabels="labels-infochart"
-                                lablesType="gcapp.freeRangePicker"
-                                classAttribute="infochart-freerangemanager-action"
-                                widthPanel = {this.props.infoChartSize.widthResizable}
-                                format={this.props.timeUnit}
-                            />
-                        )}
-                        <ButtonGroup className="button-group-wrapper">
-                            <Button className="rangepicker-button" onClick={() => this.handleApplyPeriod(this.props.variable)} disabled={this.props.isInteractionDisabled}>
-                                <Glyphicon glyph="calendar" /><Message msgId="gcapp.applyPeriodButton"/>
-                            </Button>
-                            <Button className="rangepicker-button" onClick={ this.switchRangeManager } disabled={this.props.isInteractionDisabled}>
-                                <Message msgId={this.props.activeRangeManager === FIXED_RANGE
-                                    ? "gcapp.fixedRangePicker.dateRangeButton"
-                                    : "gcapp.freeRangePicker.dateRangeButton"}  />
-                            </Button>
-                        </ButtonGroup>
-                    </FormGroup>
-                    {this.props.alertMessage && (
-                        <div className="alert-date" >
-                            <strong><Message msgId="warning"/></strong>
-                            <span ><Message msgId={this.props.alertMessage}
-                                msgParams={{toData: this.state.toDataSelected,
-                                    fromData: this.state.fromDataSelected,
-                                    minDate: moment(this.props.firstAvailableDate).format(this.props.timeUnit),
-                                    maxDate: moment(this.props.lastAvailableDate).format(this.props.timeUnit)
-                                }}/></span>
-                        </div>
-                    )}
-                </Grid>
-            </Panel>
+            <div id="collapse-form-group">
+                <InfoChartForm
+                    tabList={this.props.tabList}
+                    tabVariables={this.props.tabVariables}
+                    onChangeChartVariable={this.props.onChangeChartVariable}
+                    activeTab={tabSelected}
+                    onChangeTab={this.props.onChangeTab}
+                    activeRangeManager={this.props.activeRangeManager}
+                    firstAvailableDate={this.props.firstAvailableDate}
+                    lastAvailableDate={this.props.lastAvailableDate}
+                    toData={this.props.toData}
+                    periodType={this.props.periodType}
+                    periodTypes={this.props.periodTypes}
+                    onChangeFixedRangeTodata={this.props.onChangeFixedRangeTodata}
+                    onChangePeriod={this.props.onChangePeriod}
+                    infoChartSize={this.props.infoChartSize}
+                    timeUnit={this.props.timeUnit}
+                    fromData={this.props.fromData}
+                    onChangeFromData={this.props.onChangeFromData}
+                    onChangeToData={this.props.onChangeToData}
+                    handleApplyPeriod={this.handleApplyPeriod}
+                    variable={this.props.variable}
+                    isInteractionDisabled={this.props.isInteractionDisabled}
+                    onSetRangeManager={this.props.onSetRangeManager}
+                    alertMessage={this.props.alertMessage}
+                    toDataSelected={this.state.toDataSelected}
+                    fromDataSelected={this.state.fromDataSelected}
+                />
+            </div>
         );
     }
     getBody = () => {
@@ -459,7 +413,6 @@ class InfoChart extends React.Component {
                         minConstraints={[400, 600]}
                         style={{
                             flexDirection: "column",
-                            // top: -15,
                             right: 17,
                             padding: "5px",
                             margin: "-15px 0px -10px 0px"
@@ -503,18 +456,6 @@ class InfoChart extends React.Component {
         if (this.props.alertMessage) {
             this.props.onCloseAlert();
         }
-    }
-    handleChangePeriod = (periodType) => {
-        this.props.onChangePeriod(periodType);
-        this.handleApplyPeriod(null, null, periodType);
-    }
-    handleChangeTab = (idTab) => {
-        this.props.onChangeTab(idTab);
-        this.handleApplyPeriod(this.props.tabVariables.find(tab => tab.id === idTab).variables, idTab, null);
-    }
-    updateSingleVariable = (selectedVariable, tabVariable) => {
-        this.props.onChangeChartVariable(tabVariable, [selectedVariable]);
-        this.handleApplyPeriod([selectedVariable], tabVariable);
     }
     resetChartData = () => {
         if ( this.props.activeRangeManager === FIXED_RANGE) {

--- a/js/components/infochart/InfoChartForm.jsx
+++ b/js/components/infochart/InfoChartForm.jsx
@@ -1,7 +1,14 @@
-// FormGroup.js
+/*
+ * Copyright 2024, Riccardo Mari - CNR-Ibimet - Consorzio LaMMA.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+*/
 import React from 'react';
 import { Button, ButtonGroup, Glyphicon, Panel, Grid, Label} from 'react-bootstrap';
 import SelectVariableTab from '../buttons/SelectVariableTab';
+import TabBar from '../buttons/TabBar';
 import FixedRangeManager from '../../components/datepickers/FixedRangeManager';
 import FreeRangeManager from '../../components/datepickers/FreeRangeManager';
 import Message from '@mapstore/components/I18N/Message';
@@ -35,7 +42,8 @@ const InfoChartForm = ({
     onSetRangeManager,
     alertMessage,
     toDataSelected,
-    fromDataSelected
+    fromDataSelected,
+    handleChangeChartType
 }) => {
     const handleChangePeriod = (newPeriodType) => {
         onChangePeriod(newPeriodType);
@@ -53,6 +61,11 @@ const InfoChartForm = ({
         onChangeChartVariable(newIdTab, [selectedVariable]);
         handleApplyPeriod([selectedVariable], newIdTab);
     };
+    const isTabBarVisible = () => {
+        return activeTab.variables[0].chartList && activeTab.variables[0].chartList.length > 1;
+    };
+    const rangepickerButtonFlexDirection = (!isTabBarVisible() || infoChartSize?.widthResizable > 460) ? 'row' : 'column';
+
     return (
         <Panel className="infochart-panel">
             <Grid fluid style={{ padding: 0 }}>
@@ -97,16 +110,34 @@ const InfoChartForm = ({
                         format={timeUnit}
                     />
                 )}
-                <ButtonGroup className="button-group-wrapper">
-                    <Button className="rangepicker-button" onClick={() => handleApplyPeriod(variable)} disabled={isInteractionDisabled}>
-                        <Glyphicon glyph="calendar" /><Message msgId="gcapp.applyPeriodButton" />
-                    </Button>
-                    <Button className="rangepicker-button" onClick={switchRangeManager} disabled={isInteractionDisabled}>
-                        <Message msgId={activeRangeManager === FIXED_RANGE
-                            ? "gcapp.fixedRangePicker.dateRangeButton"
-                            : "gcapp.freeRangePicker.dateRangeButton"} />
-                    </Button>
-                </ButtonGroup>
+                <div className="button-group-wrapper">
+                    { isTabBarVisible() && (
+                        <TabBar
+                            tabList={activeTab?.variables[0]?.chartList || []}
+                            activeTab={activeTab?.variables[0]?.chartList?.find(chart => chart.active)}
+                            onChangeTab={handleChangeChartType}
+                            classAttribute={"chart-type"}
+                        />
+                    )}
+                    <ButtonGroup className="rangepicker-button-container"
+                        style={{
+                            flexDirection: rangepickerButtonFlexDirection,
+                            alignItems: 'flex-end',
+                            marginLeft: 'auto',
+                            gap: '10px',
+                            top: (!isTabBarVisible() || infoChartSize?.widthResizable > 460) ? undefined : '10px'}}>
+                        <Button className="rangepicker-button" onClick={() => handleApplyPeriod(variable)} disabled={isInteractionDisabled}
+                            style={{ marginTop: (!isTabBarVisible() || infoChartSize?.widthResizable > 460) ? '20px' : undefined }}>
+                            <Glyphicon glyph="calendar" /><Message msgId="gcapp.applyPeriodButton" />
+                        </Button>
+                        <Button className="rangepicker-button" onClick={switchRangeManager} disabled={isInteractionDisabled}
+                            style={{ marginTop: (!isTabBarVisible() || infoChartSize?.widthResizable > 460) ? '20px' : undefined }}>
+                            <Message msgId={activeRangeManager === FIXED_RANGE
+                                ? "gcapp.fixedRangePicker.dateRangeButton"
+                                : "gcapp.freeRangePicker.dateRangeButton"} />
+                        </Button>
+                    </ButtonGroup>
+                </div>
                 {alertMessage && (
                     <div className="alert-date" >
                         <strong><Message msgId="warning" /></strong>

--- a/js/components/infochart/InfoChartForm.jsx
+++ b/js/components/infochart/InfoChartForm.jsx
@@ -1,0 +1,127 @@
+// FormGroup.js
+import React from 'react';
+import { Button, ButtonGroup, Glyphicon, Panel, Grid, Label} from 'react-bootstrap';
+import SelectVariableTab from '../buttons/SelectVariableTab';
+import FixedRangeManager from '../../components/datepickers/FixedRangeManager';
+import FreeRangeManager from '../../components/datepickers/FreeRangeManager';
+import Message from '@mapstore/components/I18N/Message';
+import moment from 'moment';
+import momentLocaliser from 'react-widgets/lib/localizers/moment';
+momentLocaliser(moment);
+import { FIXED_RANGE, FREE_RANGE }  from '../../utils/VariabiliMeteoUtils';
+
+const InfoChartForm = ({
+    tabList,
+    tabVariables,
+    onChangeChartVariable,
+    activeTab, // Riceve direttamente il valore di activeTab
+    onChangeTab,
+    activeRangeManager,
+    firstAvailableDate,
+    lastAvailableDate,
+    toData,
+    periodType,
+    periodTypes,
+    onChangeFixedRangeTodata,
+    onChangePeriod,
+    infoChartSize,
+    timeUnit,
+    fromData,
+    onChangeFromData,
+    onChangeToData,
+    handleApplyPeriod,
+    variable,
+    isInteractionDisabled,
+    onSetRangeManager,
+    alertMessage,
+    toDataSelected,
+    fromDataSelected
+}) => {
+    const handleChangePeriod = (newPeriodType) => {
+        onChangePeriod(newPeriodType);
+        this.handleApplyPeriod(null, null, newPeriodType);
+    };
+    const handleChangeTab = (newIdTab) => {
+        onChangeTab(newIdTab);
+        handleApplyPeriod(tabVariables.find(tab => tab.id === newIdTab).variables, newIdTab, null);
+    };
+    const switchRangeManager = () => {
+        const newRangeManager = activeRangeManager === FIXED_RANGE ? FREE_RANGE : FIXED_RANGE;
+        onSetRangeManager(newRangeManager);
+    };
+    const updateSingleVariable = (selectedVariable, newIdTab) => {
+        onChangeChartVariable(newIdTab, [selectedVariable]);
+        handleApplyPeriod([selectedVariable], newIdTab);
+    };
+    return (
+        <Panel className="infochart-panel">
+            <Grid fluid style={{ padding: 0 }}>
+                <Label className="labels-infochart"><Message msgId="infochart.selectMeteoVariable" /></Label>
+                <SelectVariableTab
+                    idContainer="infochart-dropdown-container"
+                    activeTab={activeTab}
+                    tabList={tabList}
+                    onChangeSingleVariable={updateSingleVariable}
+                    onChangeMultiVariable={onChangeChartVariable}
+                    onChangeTab={handleChangeTab}
+                    isInteractionDisabled={false}
+                />
+                {activeRangeManager === FIXED_RANGE ? (
+                    <FixedRangeManager
+                        minDate={firstAvailableDate}
+                        maxDate={lastAvailableDate}
+                        toData={toData}
+                        periodType={periodType}
+                        periodTypes={periodTypes}
+                        onChangeToData={onChangeFixedRangeTodata}
+                        onChangePeriod={handleChangePeriod}
+                        isInteractionDisabled={isInteractionDisabled}
+                        styleLabels="labels-infochart"
+                        classAttribute="infochart-fixedrangemanager-action"
+                        widthPanel={infoChartSize.widthResizable}
+                        format={timeUnit}
+                    />
+                ) : (
+                    <FreeRangeManager
+                        minDate={firstAvailableDate}
+                        maxDate={lastAvailableDate}
+                        fromData={fromData}
+                        toData={toData}
+                        onChangeFromData={onChangeFromData}
+                        onChangeToData={onChangeToData}
+                        isInteractionDisabled={isInteractionDisabled}
+                        styleLabels="labels-infochart"
+                        lablesType="gcapp.freeRangePicker"
+                        classAttribute="infochart-freerangemanager-action"
+                        widthPanel={infoChartSize.widthResizable}
+                        format={timeUnit}
+                    />
+                )}
+                <ButtonGroup className="button-group-wrapper">
+                    <Button className="rangepicker-button" onClick={() => handleApplyPeriod(variable)} disabled={isInteractionDisabled}>
+                        <Glyphicon glyph="calendar" /><Message msgId="gcapp.applyPeriodButton" />
+                    </Button>
+                    <Button className="rangepicker-button" onClick={switchRangeManager} disabled={isInteractionDisabled}>
+                        <Message msgId={activeRangeManager === FIXED_RANGE
+                            ? "gcapp.fixedRangePicker.dateRangeButton"
+                            : "gcapp.freeRangePicker.dateRangeButton"} />
+                    </Button>
+                </ButtonGroup>
+                {alertMessage && (
+                    <div className="alert-date" >
+                        <strong><Message msgId="warning" /></strong>
+                        <span><Message msgId={alertMessage}
+                            msgParams={{
+                                toData: toDataSelected,
+                                fromData: fromDataSelected,
+                                minDate: moment(firstAvailableDate).format(timeUnit),
+                                maxDate: moment(lastAvailableDate).format(timeUnit)
+                            }} /></span>
+                    </div>
+                )}
+            </Grid>
+        </Panel>
+    );
+};
+
+export default InfoChartForm;

--- a/js/components/infochart/infochart.css
+++ b/js/components/infochart/infochart.css
@@ -20,15 +20,16 @@
 }
 
 .button-group-wrapper {
-    position: relative;
     display: flex;
-    justify-content: flex-end;
-    gap: 10px; /* Distanza tra i pulsanti invece di margini negativi */
+    justify-content: space-between; /* Distribuisce lo spazio tra gli elementi figli */
+    align-items: center; /* Allinea verticalmente al centro (opzionale) */
+    width: 100%; /* Assicurati che il div abbia una larghezza */
 }
 
-.rangepicker-button {
-    margin-top: 20px; /* Sposta i pulsanti verso il basso */
-    padding: 5px 10px; /* Migliora la dimensione cliccabile */
+.rangepicker-button-container { /* Questo ora stila il ButtonGroup */
+    margin-left: auto; /* Spinge questo contenitore a destra */
+    display: flex; /* Potrebbe non essere necessario per ButtonGroup */
+    gap: 10px; /* Spazio tra i bottoni */
 }
 
 .infochart-panel {
@@ -52,9 +53,9 @@
     border-bottom: 1px solid #ccc;
     cursor: pointer;
     position: relative;
-    top: -60px;
-    margin-bottom: -40px;
     pointer-events: none;
+    margin-bottom: 10px;
+    top: 20px
 }
 
 .chart-type-tabbar-item {
@@ -88,3 +89,4 @@
 #infochart-fixedrangemanager-action-dropdownlist{
     width: 150px;
   }
+

--- a/js/components/infochart/infochart.css
+++ b/js/components/infochart/infochart.css
@@ -24,8 +24,6 @@
     display: flex;
     justify-content: flex-end;
     gap: 10px; /* Distanza tra i pulsanti invece di margini negativi */
-    margin-top: -10px;
-    margin-bottom: -15px
 }
 
 .rangepicker-button {


### PR DESCRIPTION
The key changes implemented include:

- Re-positioned the TabBar within the button group wrapper to prevent it from being unintentionally hidden when the panel width was constrained.
- Introduced a dynamic layout for the date range picker buttons:
    - When there is sufficient horizontal space (or when the TabBar is not visible), the buttons are displayed in a row alongside the TabBar.
    - When the panel width is narrow and the TabBar is visible, the buttons now stack vertically, aligned to the right.
- Added a conditional top margin to the buttons to improve spacing when they are laid out horizontally.
- other layout adjustments