### PR TITLE
feat(charts): Implement dynamic data fetching on chart type change

### DIFF
--- a/configs/pluginsConfig.json
+++ b/configs/pluginsConfig.json
@@ -1064,7 +1064,8 @@
                     "id": "aib2",
                     "name": "Storico",
                     "chartType": "aib_historic_chart",
-                    "hideClimatologicalTrace": true
+                    "hideClimatologicalTrace": true,
+                    "needsDataReload": true
                   }
             ],
             "groupList": [

--- a/js/actions/daterangelabel.js
+++ b/js/actions/daterangelabel.js
@@ -9,6 +9,8 @@ export const UPDATE_RANGE_LABEL = 'RANGE_LABEL:UPDATE_RANGE_LABEL';
 export const NOT_FOUND_LAYER = 'RANGE_LABEL:NOT_FOUND_LAYER';
 export const LAYER_DATE_MISSING = 'RANGE_LABEL:LAYER_DATE_MISSING';
 export const SET_VARIABILIMETEO = 'RANGE_LABEL:SET_VARIABILIMETEO';
+export const PLUGIN_LOADED = 'RANGE_LABEL:PLUGIN_LOADED';
+export const PLUGIN_NOT_LOADED = 'RANGE_LABEL:PLUGIN_NOT_LOADED';
 
 export function updateDatesLayer(layerId, fromData, toData) {
     return {
@@ -37,5 +39,17 @@ export function setVariabiliMeteo(variabiliMeteo) {
     return {
         type: SET_VARIABILIMETEO,
         variabiliMeteo
+    };
+}
+
+export function markAsLoaded() {
+    return {
+        type: PLUGIN_LOADED
+    };
+}
+
+export function markAsNotLoaded() {
+    return {
+        type: PLUGIN_NOT_LOADED
     };
 }

--- a/js/components/infochart/InfoChart.jsx
+++ b/js/components/infochart/InfoChart.jsx
@@ -193,7 +193,6 @@ class InfoChart extends React.Component {
         // Default date values to use in case of invalid or missing date input
         fromDataSelected: moment(this.props.fromData).clone().format(this.props.timeUnit),
         toDataSelected: moment(this.props.toData).clone().format(this.props.timeUnit)
-        // periodTypeSelected: this.props.periodType
     }
 
     initializeTabs = () => {

--- a/js/epics/dateRangeConfig.js
+++ b/js/epics/dateRangeConfig.js
@@ -158,7 +158,8 @@ const setPluginsDatesOnInitEpic = (action$, store) =>
 
 const updateRangePickerInfoEpic = (action$, store) =>
     action$.ofType(LAYER_LOAD)
-        .mergeMap(({layerId}) => {
+        .filter(({layerId}) => layerId)
+        .switchMap(({layerId}) => {
             const currentState = store.getState();
             const layers = currentState.layers?.flat || [];
             const variabiliMeteo = getVariabiliMeteo(currentState);

--- a/js/epics/dateRangeConfig.js
+++ b/js/epics/dateRangeConfig.js
@@ -157,6 +157,17 @@ const setPluginsDatesOnInitEpic = (action$, store) =>
             return Observable.of(...actionsSetPluginsDates);
         });
 
+/**
+ * Epic that reacts to LAYER_LOAD actions and updates the range picker
+ * (fixed or free) with the correct date range based on the loaded layer.
+ *
+ * It filters out events without a layerId or if neither range picker plugin is loaded.
+ * Then, for layers corresponding to meteorological variables, it extracts the `fromData`
+ * and `toData` parameters to update the corresponding date selector.
+ *
+ * If the layer is not found, not relevant, or missing required date parameters,
+ * appropriate error actions are dispatched.
+ */
 const updateRangePickerInfoEpic = (action$, store) =>
     action$.ofType(LAYER_LOAD)
         .filter(({layerId}) => {

--- a/js/epics/dateRangeConfig.js
+++ b/js/epics/dateRangeConfig.js
@@ -13,7 +13,7 @@ import { FETCHED_AVAILABLE_DATES,  updateDatesLayer, errorLayerNotFound, errorLa
 import { TOGGLE_PLUGIN, changePeriod, changePeriodToData } from '../actions/fixedrangepicker';
 import { changeFromData, changeToData } from '../actions/freerangepicker';
 import { isPluginLoadedSelector as isFreeRangeLoaded } from '../selectors/freeRangePicker';
-import { isPluginLoadedSelector as isFixedRangeLoaded } from '../selectors/fixedRangePicker';
+import { isPluginLoadedSelector as isFixedRangeLoaded, isInOneDatePickerMode } from '../selectors/fixedRangePicker';
 import DateAPI from '../utils/ManageDateUtils';
 import { FIXED_RANGE, FREE_RANGE, getVisibleLayers, getVariabiliMeteo, isVariabiliMeteoLayer  } from '@js/utils/VariabiliMeteoUtils';
 import moment from 'moment';
@@ -99,7 +99,7 @@ const updateParamsByDateRangeEpic = (action$, store) =>
         })
         .switchMap((action) => {
             const appState = store.getState();
-            const isMapfilenameNotChange = appState.fixedrangepicker?.isPluginLoaded && appState.fixedrangepicker?.showOneDatePicker;
+            const isMapfilenameNotChange = isFixedRangeLoaded(appState) && isInOneDatePickerMode(appState);
             const layers = action.payload.config?.map?.layers || [];
             const toData = action.payload.availableDate;
             const timeUnit = action.payload.timeUnit;

--- a/js/epics/dateRangeConfig.js
+++ b/js/epics/dateRangeConfig.js
@@ -11,10 +11,11 @@ import { LAYER_LOAD, updateSettings, updateNode } from '@mapstore/actions/layers
 import { layersSelector } from '@mapstore/selectors/layers';
 import { FETCHED_AVAILABLE_DATES,  updateDatesLayer, errorLayerNotFound, errorLayerDateMissing  } from '../actions/updateDatesParams';
 import { TOGGLE_PLUGIN, changePeriod, changePeriodToData } from '../actions/fixedrangepicker';
-import { changeFromData, changeToData  } from '../actions/freerangepicker';
+import { changeFromData, changeToData } from '../actions/freerangepicker';
+import { isPluginLoadedSelector as isFreeRangeLoaded } from '../selectors/freeRangePicker';
+import { isPluginLoadedSelector as isFixedRangeLoaded } from '../selectors/fixedRangePicker';
 import DateAPI from '../utils/ManageDateUtils';
-import { getVisibleLayers, FIXED_RANGE, FREE_RANGE } from '@js/utils/VariabiliMeteoUtils';
-import {  getVariabiliMeteo, isVariabiliMeteoLayer } from '../utils/VariabiliMeteoUtils';
+import { FIXED_RANGE, FREE_RANGE, getVisibleLayers, getVariabiliMeteo, isVariabiliMeteoLayer  } from '@js/utils/VariabiliMeteoUtils';
 import moment from 'moment';
 import momentLocaliser from 'react-widgets/lib/localizers/moment';
 momentLocaliser(moment);
@@ -158,7 +159,10 @@ const setPluginsDatesOnInitEpic = (action$, store) =>
 
 const updateRangePickerInfoEpic = (action$, store) =>
     action$.ofType(LAYER_LOAD)
-        .filter(({layerId}) => layerId)
+        .filter(({layerId}) => {
+            const currentState = (store.getState());
+            return  layerId && (isFixedRangeLoaded(currentState) || isFreeRangeLoaded(currentState));
+        })
         .switchMap(({layerId}) => {
             const currentState = store.getState();
             const layers = currentState.layers?.flat || [];

--- a/js/epics/daterangelabel.js
+++ b/js/epics/daterangelabel.js
@@ -12,7 +12,11 @@ import { isVariabiliMeteoLayer } from '../utils/VariabiliMeteoUtils';
 
 const updateDateLabelEpic = (action$, store) =>
     action$.ofType(LAYER_LOAD)
-        .mergeMap(({layerId}) => {
+        .filter(({layerId}) => {
+            const pluginState = store.getState().daterangelabel || {};
+            return layerId && pluginState.isPluginLoaded;
+        })
+        .switchMap(({layerId}) => {
             const currentState = store.getState();
             const layers = currentState.layers?.flat || [];
             const variabiliMeteo = currentState.daterangelabel.variabiliMeteo;

--- a/js/epics/infochart.js
+++ b/js/epics/infochart.js
@@ -13,6 +13,8 @@ import { updateAdditionalLayer, addAdditionalLayers, removeAdditionalLayer  } fr
 import {
     TOGGLE_INFOCHART,
     FETCH_INFOCHART_DATA,
+    SET_INFOCHART_VISIBILITY,
+    PLUGIN_NOT_LOADED,
     fetchedInfoChartData,
     setInfoChartVisibility,
     fetchInfoChartData,
@@ -515,13 +517,21 @@ const loadInfoChartDataEpic = (action$, store) =>
             ).switchMap(data => {
                 const actions = checkResponseData(data, state);
                 return Observable.of(...actions);
-            }).catch(error => {
-                const errorHandlingActions = getErrorHandlingActions(error);
-                return Observable.concat(
-                    ...errorHandlingActions.map(action => Observable.of(action)),
-                    Observable.throw(error)
-                );
-            });
+            })
+                .takeUntil(
+                    action$.ofType(SET_INFOCHART_VISIBILITY, PLUGIN_NOT_LOADED)
+                        .filter(action =>
+                            action.type === PLUGIN_NOT_LOADED ||
+                            (action.type === SET_INFOCHART_VISIBILITY && action.status === false)
+                        )
+                )
+                .catch(error => {
+                    const errorHandlingActions = getErrorHandlingActions(error);
+                    return Observable.concat(
+                        ...errorHandlingActions.map(action => Observable.of(action)),
+                        Observable.throw(error)
+                    );
+                });
         });
 
 

--- a/js/plugins/DateRangeLabel.jsx
+++ b/js/plugins/DateRangeLabel.jsx
@@ -10,7 +10,7 @@ import React from "react";
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { DATE_FORMAT } from '../utils/ManageDateUtils';
-import { setVariabiliMeteo } from '../actions/daterangelabel';
+import { setVariabiliMeteo, markAsLoaded, markAsNotLoaded } from '../actions/daterangelabel';
 import daterangelabel from '../reducers/daterangelabel';
 import assign from 'object-assign';
 import updateDateLabelEpic from '../epics/daterangelabel';
@@ -41,7 +41,10 @@ class DateRangeLabel extends React.Component {
         onSetVariabiliMeteo: PropTypes.func,
         style: PropTypes.object,
         id: PropTypes.string,
+        isPluginLoaded: PropTypes.bool,
         fromData: PropTypes.instanceOf(Date),
+        onMarkPluginAsLoaded: PropTypes.func,
+        onMarkPluginAsNotLoaded: PropTypes.func,
         toData: PropTypes.instanceOf(Date),
         variabiliMeteo: PropTypes.object,
         timeUnit: PropTypes.string
@@ -67,6 +70,14 @@ class DateRangeLabel extends React.Component {
     };
     componentDidMount() {
         this.props.onSetVariabiliMeteo(this.props.variabiliMeteo);
+        if (!this.props.isPluginLoaded) {
+            this.props.onMarkPluginAsLoaded();
+        }
+    }
+    componentWillUnmount() {
+        if (this.props.isPluginLoaded) {
+            this.props.onMarkPluginAsNotLoaded();
+        }
     }
     render() {
         return (
@@ -84,13 +95,16 @@ const mapStateToProps = (state) => {
     return {
         variabiliMeteo: state.daterangelabel?.variabiliMeteo,
         fromData: state.daterangelabel?.fromData ? new Date(state.daterangelabel.fromData) : new Date(moment().subtract(1, 'month')._d),
-        toData: state.daterangelabel?.toData ? new Date(state.daterangelabel.toData) : new Date(moment().subtract(1, 'day')._d)
+        toData: state.daterangelabel?.toData ? new Date(state.daterangelabel.toData) : new Date(moment().subtract(1, 'day')._d),
+        isPluginLoaded: state.daterangelabel?.isPluginLoaded
     };
 };
 
 const DateRangeLabelPlugin = connect(
     mapStateToProps, {
-        onSetVariabiliMeteo: setVariabiliMeteo
+        onSetVariabiliMeteo: setVariabiliMeteo,
+        onMarkPluginAsLoaded: markAsLoaded,
+        onMarkPluginAsNotLoaded: markAsNotLoaded
     }
 )(DateRangeLabel);
 

--- a/js/plugins/FixedRangePicker.jsx
+++ b/js/plugins/FixedRangePicker.jsx
@@ -160,7 +160,7 @@ class FixedRangePicker extends React.Component {
         settings: PropTypes.object,
         shiftDown: PropTypes.bool,
         shiftRight: PropTypes.bool,
-        showOneDatePicker: PropTypes.bool,
+        showOneDatePicker: PropTypes.bool, // true when the FixedRange plugin is loaded in "One Date Picker" mode.
         showChangeRangePickerButton: PropTypes.bool,
         style: PropTypes.object,
         timeUnit: PropTypes.string,
@@ -215,12 +215,6 @@ class FixedRangePicker extends React.Component {
         isPluginLoaded: false,
         timeUnit: DATE_FORMAT
     };
-
-    // state = {
-    //     fromDataAlertMessage: moment(this.props.fromDataLayer).clone().format(this.props.timeUnit),
-    //     toDataAlertMessage: moment(this.props.toDataLayer).clone().format(this.props.timeUnit),
-    //     defaultPeriodType: this.props.periodType
-    // }
 
     componentDidMount() {
         const defaultPeriod = DateAPI.getDefaultPeriod(this.props.periodTypes);
@@ -289,7 +283,7 @@ class FixedRangePicker extends React.Component {
             </div>
         );
     }
-
+    // The plugin is loaded in "Date Range Picker" mode.
     showFixedRangeManager = () => {
         return (
             <div className="ms-fixedrangepicker-action">
@@ -326,6 +320,7 @@ class FixedRangePicker extends React.Component {
             </div>
         );
     }
+    // The plugin is loaded in "One Date Picker" mode.
     showDailyDatePicker = () => {
         return (
             <DailyManager

--- a/js/plugins/InfoChart.jsx
+++ b/js/plugins/InfoChart.jsx
@@ -331,7 +331,8 @@ Plugin configuration
                     "id": "aib2",
                     "name": "Previsonale",
                     "chartType": "aib_previsionale",
-                    "showOneDatePicker": true
+                    "showOneDatePicker": true,
+                    "needsDataReload": true
                   }
             ],
             "groupList": [

--- a/js/reducers/daterangelabel.js
+++ b/js/reducers/daterangelabel.js
@@ -5,11 +5,12 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
 */
-import { UPDATE_RANGE_LABEL, SET_VARIABILIMETEO } from '../actions/daterangelabel';
+import { UPDATE_RANGE_LABEL, SET_VARIABILIMETEO, PLUGIN_LOADED, PLUGIN_NOT_LOADED } from '../actions/daterangelabel';
 
 const defaultState = {
     fromData: new Date(),
-    toData: new Date()
+    toData: new Date(),
+    isPluginLoaded: false
 };
 
 function daterangelabel(state = defaultState, action) {
@@ -24,6 +25,12 @@ function daterangelabel(state = defaultState, action) {
         return {
             ...state,
             variabiliMeteo: action.variabiliMeteo
+        };
+    case PLUGIN_LOADED:
+    case PLUGIN_NOT_LOADED:
+        return {
+            ...state,
+            isPluginLoaded: action.type === PLUGIN_LOADED
         };
     default:
         return state;

--- a/js/reducers/exportimage.js
+++ b/js/reducers/exportimage.js
@@ -18,7 +18,7 @@ const defaultState = {
     tabVariables: []
 };
 
-function daterangelabel(state = defaultState, action) {
+function exportimage(state = defaultState, action) {
     switch (action.type) {
     case UPDATE_DATES:
         return {
@@ -83,11 +83,9 @@ function daterangelabel(state = defaultState, action) {
         };
     case CLEAR_IMAGE_URL:
         return { ...state, imageUrl: null, fileName: DEFAULT_FILENAME };
-    // case TOGGLE_PLUGIN:
-    //     return { ...state, isPluginOpen: action.payload };
     default:
         return state;
     }
 }
 
-export default daterangelabel;
+export default exportimage;

--- a/js/selectors/fixedRangePicker.js
+++ b/js/selectors/fixedRangePicker.js
@@ -62,3 +62,9 @@ export const isCollapsedPluginSelector = createSelector(
     [getFixedRangePickerState],
     (fixedrangepicker) => fixedrangepicker?.isCollapsedPlugin || false
 );
+
+// Returns true when the FixedRange plugin is loaded in "One Date Picker" mode.
+export const isInOneDatePickerMode = createSelector(
+    [getFixedRangePickerState],
+    (fixedrangepicker) => !!fixedrangepicker?.showOneDatePicker
+);


### PR DESCRIPTION
This PR introduces a new Redux-Observable epic to dynamically fetch chart data when the chart type is changed via tab selection.

The epic:
- Intercepts `CHART_TYPE_CHANGED` actions.
- Filters based on a `needsDataReload` flag found in the active tab's chart configuration.
- Dispatches `FETCH_INFOCHART_DATA` with the appropriate parameters, or `EMPTY` if no valid variables are found.

This change improves data loading logic and prevents unnecessary API calls.

Bug Fixes Included